### PR TITLE
Improve odd status code check

### DIFF
--- a/get_data.py
+++ b/get_data.py
@@ -17,7 +17,7 @@ def walk_index(path):
 
 def get_license(crate_name):
     req = requests.get(CRATE_URL.format(crate_name=crate_name))
-    if req.status_code / 100 == 2:
+    if req.status_code == requests.codes.ok:
         try:
             j = req.json()
             crate = j['crate']


### PR DESCRIPTION
The script is Python 3 which uses real division (rather than
integer division), so `a / 100 == 2` is just an overly complex
way to write `a == 200`, and requests provides a bunch of
constants for various status codes so might as well use that.

If the intent was to check if the status code is between 200 and
300, I would suggest `status in range(200, 300)` or `200 <=
status < 300`. Request's symbolic constants for these bounds are
respectively `requests.codes.ok` and
`requests.codes.multiple_choices`.
